### PR TITLE
fix(arubacloud-resource-operator): support manual vault setup in multi auth mode

### DIFF
--- a/charts/arubacloud-resource-operator/README.md
+++ b/charts/arubacloud-resource-operator/README.md
@@ -89,18 +89,42 @@ helm upgrade --install arubacloud-operator arubacloud/arubacloud-resource-operat
 
 #### Multi-Tenant Installation (Vault-based)
 
-For multi-tenant deployments using HashiCorp Vault:
+Multi-tenant mode uses HashiCorp Vault AppRole authentication to retrieve per-tenant credentials. Two sub-modes control how Vault is provisioned:
+
+| `config.auth.multi.setup` | `vault.enabled` | Description |
+|---|---|---|
+| `auto` (default) | `true` | Chart installs Vault in dev mode and configures it automatically. For development/demo only. |
+| `manual` | `false` | You provide a pre-existing Vault instance. All Vault parameters must be supplied. |
+
+##### Setup = manual (bring your own Vault)
+
+Use this when Vault is already running outside the cluster (or managed separately):
 
 ```bash
 helm install arubacloud-operator arubacloud/arubacloud-resource-operator \
   --namespace aruba-system \
   --create-namespace \
   --set config.auth.mode=multi \
+  --set config.auth.multi.setup=manual \
+  --set vault.enabled=false \
   --set config.auth.multi.vault.address=<vault-address> \
-  --set config.auth.multi.vault.rolePath=<vault-role-path> \
+  --set config.auth.multi.vault.kvMount=<kv-mount> \
+  --set config.auth.multi.vault.rolePath=<approle-path> \
   --set config.auth.multi.vault.roleId=<vault-role-id> \
-  --set config.auth.multi.vault.roleSecret=<vault-role-secret> \ 
-  --set config.auth.multi.vault.kvMount=<vault-role-kvMount>
+  --set config.auth.multi.vault.roleSecret=<vault-role-secret>
+```
+
+##### Setup = auto (chart-managed Vault, dev/demo only)
+
+Use this to let the chart install and configure Vault automatically. **Not for production.**
+
+```bash
+helm install arubacloud-operator arubacloud/arubacloud-resource-operator \
+  --namespace aruba-system \
+  --create-namespace \
+  --set config.auth.mode=multi \
+  --set config.auth.multi.setup=auto \
+  --set vault.enabled=true
 ```
 
 ##### Alternative: Using Secret References for Vault AppRole Credentials
@@ -258,13 +282,17 @@ _output:_
 | `config.auth.mode` | Authentication mode: `single` or `multi` | `single` |
 | `config.auth.single.clientId` | OAuth client ID (required when mode is `single`) | `""` |
 | `config.auth.single.clientSecret` | OAuth client secret (required when mode is `single`) | `""` |
-| `config.auth.multi.vault.address` | Vault server address (used when mode is `multi`) | `http://vault0.default.svc.cluster.local:8200` |
-| `config.auth.multi.vault.kvMount` | Vault KV mount path (used when mode is `multi`) | `kw` |
-| `config.auth.multi.vault.rolePath` | Vault AppRole path (used when mode is `multi`) | `approle` |
+| `config.auth.multi.setup` | Vault provisioning mode: `manual` (bring your own Vault) or `auto` (chart installs Vault, dev/demo only) | `auto` |
+| `config.auth.multi.vault.address` | Vault server address (required when mode is `multi`) | `http://vault:8200` |
+| `config.auth.multi.vault.kvMount` | Vault KV mount path (required when mode is `multi`) | `kv` |
+| `config.auth.multi.vault.rolePath` | Vault AppRole path (required when mode is `multi`) | `approle` |
 | `config.auth.multi.vault.roleId` | Vault AppRole ID (required when mode is `multi` and `roleIdFrom` is not set) | `""` |
 | `config.auth.multi.vault.roleSecret` | Vault AppRole secret (required when mode is `multi` and `roleSecretFrom` is not set) | `""` |
 | `config.auth.multi.vault.roleIdFrom.secretKeyRef` | Reference to existing secret for Vault AppRole ID (alternative to `roleId`) | - |
 | `config.auth.multi.vault.roleSecretFrom.secretKeyRef` | Reference to existing secret for Vault AppRole secret (alternative to `roleSecret`) | - |
+| `config.auth.multi.vault.auto.namespace` | Kubernetes namespace where Vault is deployed (used when `setup=auto`) | `vault` |
+| `config.auth.multi.vault.auto.helmChartVersion` | Vault Helm chart version to install (used when `setup=auto`) | `0.32.0` |
+| `config.auth.multi.vault.auto.devRootToken` | Vault dev root token for initial configuration (used when `setup=auto`) | `root` |
 
 ### Controller Parameters
 
@@ -298,6 +326,16 @@ _output:_
 |---------------------|--------------------------------------------------|--------------------------------|
 | `metricsService.type` | Metrics service type | `ClusterIP` |
 | `metricsService.ports` | Metrics service ports | (see values.yaml) |
+
+### Vault Sub-chart Parameters
+
+These parameters control the Vault sub-chart, which is only used when `config.auth.multi.setup=auto`. When using `setup=manual`, set `vault.enabled=false`.
+
+| Name                | Description                                      | Default                        |
+|---------------------|--------------------------------------------------|--------------------------------|
+| `vault.enabled` | Install Vault as a sub-chart. Must be `true` for `setup=auto` and `false` for `setup=manual`. | `true` |
+| `vault.server.dev.enabled` | Run Vault in dev mode (in-memory, no persistence). **Not for production.** | `true` |
+| `vault.server.dev.devRootToken` | Dev root token | `root` |
 
 Refer to the [values.yaml](values.yaml) file for a complete list of configurable parameters.
 
@@ -418,6 +456,9 @@ kubectl logs -n aruba-system -l control-plane=controller-manager -f
 - **Resource creation failures**: Check operator logs for detailed error messages. Ensure API endpoints are correct and accessible.
 - **Missing CRDs**: If you disabled automatic CRD installation (`crds.enabled=false`), ensure you've manually installed the `arubacloud-resource-operator-crd` chart.
 - **CRD version mismatch**: If CRDs were installed separately, ensure they match the version expected by the operator.
+- **`vault.enabled=true conflicts with config.auth.multi.setup=manual`**: You set `setup=manual` but left `vault.enabled=true` (the default). Add `--set vault.enabled=false` to your install command.
+- **`vault.enabled=false conflicts with config.auth.multi.setup=auto`**: You set `vault.enabled=false` but left `setup=auto` (the default). Either add `--set vault.enabled=true` or switch to `--set config.auth.multi.setup=manual` and supply your own Vault parameters.
+- **Operator pod stuck in `Init:0/1`** (setup=auto): The `wait-for-vault-credentials` initContainer is waiting for the vault-config Job to patch the operator Secret. Check the Job logs: `kubectl logs -n aruba-system -l app=vault-config`.
 
 ## Uninstall
 

--- a/charts/arubacloud-resource-operator/templates/_helpers.tpl
+++ b/charts/arubacloud-resource-operator/templates/_helpers.tpl
@@ -115,3 +115,15 @@ Create the metrics reader role name with truncation
 {{- define "operator.config" -}}
 operator-config
 {{- end }}
+
+{{/*
+Validate that vault.enabled is consistent with config.auth.multi.setup.
+*/}}
+{{- define "operator.validate" -}}
+{{- if and (eq .Values.config.auth.mode "multi") (eq .Values.config.auth.multi.setup "manual") .Values.vault.enabled }}
+{{- fail "vault.enabled=true conflicts with config.auth.multi.setup=manual. Add --set vault.enabled=false when providing Vault configuration manually." }}
+{{- end }}
+{{- if and (eq .Values.config.auth.mode "multi") (eq .Values.config.auth.multi.setup "auto") (not .Values.vault.enabled) }}
+{{- fail "vault.enabled=false conflicts with config.auth.multi.setup=auto. The Vault sub-chart is required for automatic setup. Either set vault.enabled=true or switch to setup=manual." }}
+{{- end }}
+{{- end }}

--- a/charts/arubacloud-resource-operator/templates/deployment.yaml
+++ b/charts/arubacloud-resource-operator/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "operator.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -81,7 +82,7 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controller.manager.containerSecurityContext
           | nindent 10 }}
-{{- if eq .Values.config.auth.multi.setup "auto" }}
+{{- if and (eq .Values.config.auth.mode "multi") (eq .Values.config.auth.multi.setup "auto") }}
       initContainers:
       - name: wait-for-vault-credentials
         image: bitnami/kubectl:latest

--- a/charts/arubacloud-resource-operator/values.yaml
+++ b/charts/arubacloud-resource-operator/values.yaml
@@ -90,12 +90,14 @@ serviceAccount:
   create: true
   name: ""
 
-# -- Vault sub-chart values. Set vault.enabled=true when config.auth.multi.setup=auto.
+# -- Vault sub-chart values.
+# Set vault.enabled=true  when config.auth.multi.setup=auto  (chart installs and configures Vault).
+# Set vault.enabled=false when config.auth.multi.setup=manual (you supply the Vault address/credentials).
 # fullnameOverride ensures the Vault service is always reachable at http://vault.<namespace>.svc:8200
 # regardless of the Helm release name.
 # WARNING: dev mode is enabled by default — NOT for production use.
 vault:
-  # -- Set to true to install Vault as a sub-chart (required for setup=auto)
+  # -- Set to true to install Vault as a sub-chart (required for setup=auto; must be false for setup=manual)
   enabled: true
   fullnameOverride: "vault"
   injector:


### PR DESCRIPTION
## Summary

- Fix  initContainer guard: the  initContainer was gated only on , causing it to be injected even when . Now correctly requires both  AND .
- Add  helper in  that fails fast at install/upgrade time when  contradicts the chosen  mode.
- Clarify  comments on when  should be true vs false.

## Test plan

- [ ]  with  renders without initContainer and vault resources
- [ ]  with  fails with validation error
- [ ]  with  fails with validation error
- [ ]  with  renders initContainer and vault-auto resources correctly
- [ ]  with  renders no vault resources and no initContainer regardless of  value