### PR TITLE
fix(arubacloud-resource-operator): role-id and secret-id never writte…

### DIFF
--- a/charts/arubacloud-resource-operator/templates/controller-manager.yaml
+++ b/charts/arubacloud-resource-operator/templates/controller-manager.yaml
@@ -33,10 +33,10 @@ data:
   role-id: ""
   secret-id: ""
   {{- else }}
-  {{- if not .Values.config.auth.multi.vault.roleIdFrom }}
+  {{- if not .Values.config.auth.multi.vault.roleIdFrom.secretKeyRef.name }}
   role-id: {{ required "config.auth.multi.vault.roleId is required when mode is 'multi' and roleIdFrom is not set" .Values.config.auth.multi.vault.roleId | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.config.auth.multi.vault.roleSecretFrom }}
+  {{- if not .Values.config.auth.multi.vault.roleSecretFrom.secretKeyRef.name }}
   secret-id: {{ required "config.auth.multi.vault.roleSecret is required when mode is 'multi' and roleSecretFrom is not set" .Values.config.auth.multi.vault.roleSecret | b64enc | quote }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
roleIdFrom and roleSecretFrom are declared in values.yaml as nested maps (with empty name/key strings), and in Go templates any non-nil map is truthy — so if not .Values...roleIdFrom was always false, silently dropping both keys from the Secret.