### PR TITLE
feat(arubacloud-resource-operator): add kv-prefix and role-namespace …

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository hosts multiple Helm charts for Aruba Cloud, published via GitHub
 | Chart | Description | Version | Documentation |
 |-------|-------------|---------|---------------|
 | [actalis-cert-manager](./charts/actalis-cert-manager) | Installs cert-manager and configures Actalis ACME integration for automated certificate management | 1.0.0 | [README](./charts/actalis-cert-manager/README.md) |
-| [arubacloud-resource-operator](./charts/arubacloud-resource-operator) | Kubernetes operator for managing Aruba Cloud infrastructure resources through CRDs | 1.0.0 | [README](./charts/arubacloud-resource-operator/README.md) |
+| [arubacloud-resource-operator](./charts/arubacloud-resource-operator) | Kubernetes operator for managing Aruba Cloud infrastructure resources through CRDs | 1.0.1 | [README](./charts/arubacloud-resource-operator/README.md) |
 | [arubacloud-resource-operator-crd](./charts/arubacloud-resource-operator-crd) | Custom Resource Definitions for the Aruba Cloud Resource Operator | 1.0.0 | [README](./charts/arubacloud-resource-operator-crd/README.md) |
 | [cluster-autoscaler](./charts/cluster-autoscaler) | Kubernetes cluster autoscaler for automatic node scaling | 1.0.0 | [README](./charts/cluster-autoscaler/README.md) |
 

--- a/charts/arubacloud-resource-operator/Chart.lock
+++ b/charts/arubacloud-resource-operator/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.32.0
-digest: sha256:5944672e1dfd1ea357c8f9238c4e0ea5bd62b472de537ec5cca53bfa078a12a8
-generated: "2026-04-20T14:59:38.5554782+02:00"
+digest: sha256:cccf6344250cb383111cd808f9ee7825e6f8252a93372802216ee43590de13b2
+generated: "2026-07-27T11:37:34.84550006+02:00"

--- a/charts/arubacloud-resource-operator/Chart.yaml
+++ b/charts/arubacloud-resource-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/arubacloud-resource-operator/README.md
+++ b/charts/arubacloud-resource-operator/README.md
@@ -109,6 +109,8 @@ helm install arubacloud-operator arubacloud/arubacloud-resource-operator \
   --set vault.enabled=false \
   --set config.auth.multi.vault.address=<vault-address> \
   --set config.auth.multi.vault.kvMount=<kv-mount> \
+  --set config.auth.multi.vault.kvPrefix=<kv-prefix> \
+  --set config.auth.multi.vault.roleNamespace=<vault-namespace> \
   --set config.auth.multi.vault.rolePath=<approle-path> \
   --set config.auth.multi.vault.roleId=<vault-role-id> \
   --set config.auth.multi.vault.roleSecret=<vault-role-secret>
@@ -285,6 +287,8 @@ _output:_
 | `config.auth.multi.setup` | Vault provisioning mode: `manual` (bring your own Vault) or `auto` (chart installs Vault, dev/demo only) | `auto` |
 | `config.auth.multi.vault.address` | Vault server address (required when mode is `multi`) | `http://vault:8200` |
 | `config.auth.multi.vault.kvMount` | Vault KV mount path (required when mode is `multi`) | `kv` |
+| `config.auth.multi.vault.kvPrefix` | Optional path prefix prepended to the tenant: `<kv-mount>/<kv-prefix>/<tenant>` | `""` |
+| `config.auth.multi.vault.roleNamespace` | Vault Enterprise namespace for AppRole auth. Leave empty for Vault OSS. | `""` |
 | `config.auth.multi.vault.rolePath` | Vault AppRole path (required when mode is `multi`) | `approle` |
 | `config.auth.multi.vault.roleId` | Vault AppRole ID (required when mode is `multi` and `roleIdFrom` is not set) | `""` |
 | `config.auth.multi.vault.roleSecret` | Vault AppRole secret (required when mode is `multi` and `roleSecretFrom` is not set) | `""` |

--- a/charts/arubacloud-resource-operator/templates/controller-manager.yaml
+++ b/charts/arubacloud-resource-operator/templates/controller-manager.yaml
@@ -10,7 +10,9 @@ data:
   realm-api: {{ .Values.config.auth.realm | quote }}
 {{- if eq .Values.config.auth.mode "multi" }}
   kv-mount: {{ .Values.config.auth.multi.vault.kvMount | quote }}
+  kv-prefix: {{ .Values.config.auth.multi.vault.kvPrefix | default "" | quote }}
   role-path: {{ .Values.config.auth.multi.vault.rolePath | quote }}
+  role-namespace: {{ .Values.config.auth.multi.vault.roleNamespace | default "" | quote }}
   vault-enabled: "true"
   vault-address: {{ .Values.config.auth.multi.vault.address | quote }}
 {{- else }}

--- a/charts/arubacloud-resource-operator/values.yaml
+++ b/charts/arubacloud-resource-operator/values.yaml
@@ -20,6 +20,8 @@ config:
       vault:
         address: http://vault:8200
         kvMount: kv
+        kvPrefix: ""
+        roleNamespace: ""
         rolePath: approle
         # Direct string values (default method)
         roleId: ""


### PR DESCRIPTION
Adds two optional Vault configuration parameters to the operator-config ConfigMap rendered by the arubacloud-resource-operator chart. Both fields are only emitted when config.auth.mode=multi and default to an empty string, so no existing deployment is affected.

kv-prefix (new)

An optional path segment prepended to the tenant when building the Vault KV v2 secret path. With this value set the operator resolves credentials at <kv-mount>/<kv-prefix>/<tenant> instead of the flat <kv-mount>/<tenant>. Required to support the kvPrefix feature introduced in sdk-go v1.0.8 and the operator v1.0.8 release.

role-namespace (new)

An optional Vault Enterprise namespace used for AppRole authentication. Previously the operator code already read role-namespace from the ConfigMap, but the chaaking it impossible toconfigure without a manual ConfigMap patch.

Test plan

- [x] helm template widers both kv-prefix androle-namespace keys in the ConfigMap
- [x] helm template with config.auth.mode=single does not render either key (gated by the multi bl
- [x] Default empty values preserve existing behaviour — no functional
change for deployments

Release notes

Bump the chart to version 1.0.1 (patch — additive, backwards-compatible change).